### PR TITLE
Add SINGLE and PROMPT parameters.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,6 +83,11 @@ default['security']['suid_sgid']['whitelist']          = []
 default['security']['suid_sgid']['remove_from_unknown'] = false
 default['security']['suid_sgid']['dry_run_on_unknown']  = false
 
+# Allow interactive startup (rhel, centos)
+default['security']['init']['prompt']                   = false
+# Require root password for single user mode. (rhel, centos)
+default['security']['init']['single']                   = true
+
 # remove packages with known issues
 default['security']['packages']['clean']               = true
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,9 +84,9 @@ default['security']['suid_sgid']['remove_from_unknown'] = false
 default['security']['suid_sgid']['dry_run_on_unknown']  = false
 
 # Allow interactive startup (rhel, centos)
-default['security']['init']['prompt']                   = false
+default['security']['init']['prompt']                   = true
 # Require root password for single user mode. (rhel, centos)
-default['security']['init']['single']                   = true
+default['security']['init']['single']                   = false
 
 # remove packages with known issues
 default['security']['packages']['clean']               = true

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -58,7 +58,10 @@ when 'rhel', 'fedora'
     mode 0544
     owner 'root'
     group 'root'
-    variables
+    variables(
+      prompt: node['security']['init']['prompt'],
+      single: node['security']['init']['single']
+    )
   end
 end
 

--- a/templates/default/rhel_sysconfig_init.erb
+++ b/templates/default/rhel_sysconfig_init.erb
@@ -21,14 +21,14 @@ SETCOLOR_WARNING="echo -en \\033[0;33m"
 # terminal sequence to reset to the default color.
 SETCOLOR_NORMAL="echo -en \\033[0;39m"
 # Set to anything other than 'no' to allow hotkey interactive startup...
-PROMPT=yes
+PROMPT=<%= @prompt ? 'yes' : 'no' %>
 # Set to 'yes' to allow probing for devices with swap signatures
 AUTOSWAP=no
 # What ttys should gettys be started on?
 ACTIVE_CONSOLES=/dev/tty[1-6]
 # Set to '/sbin/sulogin' to prompt for password on single-user mode
 # Set to '/sbin/sushell' otherwise
-SINGLE=/sbin/sushell
+SINGLE=<%= @single ? '/sbin/sulogin' : '/sbin/sushell' %>
 
 # NSA 2.2.4.1 Set Daemon umask
 umask 027


### PR DESCRIPTION
Changing settings for SINGLE and PROMPT is required for [CIS 1.5.4 - 1.5.5](https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_6_Benchmark_v1.4.0.pdf).  This PR enables these to be set and sets the recommended settings by default.
