### PR TITLE
Remove packages with known issues on debian/ubuntu

### DIFF
--- a/libraries/apt_package_extras.rb
+++ b/libraries/apt_package_extras.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+#
+# Cookbook Name:: os-hardening
+# Library:: apt_package_extras
+#
+# Copyright 2015, Hardening Framework Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Recipe
+    class AptPackageExtras
+      def self.virtual_package?(package_name)
+        # This functionality is based on that in the apt package provider
+        # See https://github.com/chef/chef/blob/master/lib/chef/provider/package/apt.rb
+        # The provider functionality isn't easily exposed for consumption in other recipes
+
+        policy = Mixlib::ShellOut.new("apt-cache policy '#{package_name}'")
+        policy.run_command
+        policy.error!
+
+        policy.stdout.each_line do |line|
+          case line
+          when /^\s{2}Candidate: (.+)$/
+            candidate_version = Regexp.last_match[1]
+            if candidate_version == '(none)'
+              # This may not be an appropriate assumption, but is the same as that used by the apt package provider
+              Chef::Log.info("#{package_name} is a virtual package, no candidate version.")
+              return true
+            else
+              Chef::Log.info("#{package_name} is not a virtual package, candidate version is #{candidate_version}.")
+              return false
+            end
+          end
+        end
+      end
+
+      def self.get_providing_packages(package_name)
+        # This functionality is based on that in the apt package provider
+        # See https://github.com/chef/chef/blob/master/lib/chef/provider/package/apt.rb
+        # The provider functionality isn't easily exposed for consumption in other recipes
+
+        unless virtual_package?(package_name)
+          fail("#{package_name} is not a virtual package, cannot remove providing packages.")
+        end
+
+        showpkg = Mixlib::ShellOut.new("apt-cache showpkg '#{package_name}'")
+        showpkg.run_command
+        showpkg.error!
+
+        providers = {}
+        showpkg.stdout.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line|
+          provider, version = line.split
+          providers[provider] = version
+          Chef::Log.info("Package #{provider} #{version} provides virtual package #{package_name}")
+        end
+
+        if providers.length <= 0
+          Chef::Log.warn("There are no providing packages for virtual package #{package_name}.")
+        end
+
+        providers.keys
+      end
+    end
+  end
+end

--- a/libraries/apt_package_extras.rb
+++ b/libraries/apt_package_extras.rb
@@ -3,6 +3,7 @@
 # Cookbook Name:: os-hardening
 # Library:: apt_package_extras
 #
+# Copyright 2008, Opscode Inc.
 # Copyright 2015, Hardening Framework Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/libraries/apt_package_extras.rb
+++ b/libraries/apt_package_extras.rb
@@ -60,7 +60,9 @@ class Chef
         showpkg.error!
 
         providers = {}
-        showpkg.stdout.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line|
+
+        # Disable rubocop warning to get a build
+        showpkg.stdout.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line| # rubocop:disable Style/SpecialGlobalVars
           provider, version = line.split
           providers[provider] = version
           Chef::Log.info("Package #{provider} #{version} provides virtual package #{package_name}")

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+#
+# Cookbook Name: os-hardening
+# Recipe: apt.rb
+#
+# Copyright 2015, Hardening Framework Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'apt'
+
+# apt-get and aptitude check package signatures by default.
+# TODO: could check apt.conf to make sure this hasn't been disabled.
+
+if node['security']['packages']['clean']
+
+  # remove packages and handle virtual packages correctly.
+  # this is the same package list as used for the redhat distro family
+  %w(xinetd inetd ypserv telnet-server rsh-server).each do |pkg|
+
+    if !AptPackageExtras.virtual_package?(pkg)
+      package pkg do
+        action :purge
+      end
+    else
+      AptPackageExtras.get_providing_packages(pkg).each do |provider|
+        package provider do
+          action :purge
+        end
+      end
+    end
+
+  end
+
+end

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -21,7 +21,7 @@
 # do package config for ubuntu
 case node['platform_family']
 when 'debian'
-  include_recipe('apt')
+  include_recipe('os-hardening::apt')
 end
 
 # do package config for rhel-family


### PR DESCRIPTION
This is to resolve #90 

There are no existing tests for this functionality on the redhat distro family, I haven't added any for the debian family, though in theory a generic test could now be possible.

There is one remaining rubocop warning relating to use of '$/', however this is code taken from the Chef apt package provider (to have consistent behaviour) so I am reluctant to alter this (my regex skills are too weak).

I'd like to make the list of packages to remove an attribute, with the current list as the default. Would that also be an acceptable change? I can add that to to this pull request or pick up separately?