### PR TITLE
Berkshelf 4 Upgrade and Ruby 1.9.3 drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 rvm:
-- 1.9.3
 - 2.0.0
 - 2.1.3
 language: ruby
@@ -8,7 +7,3 @@ bundler_args: "--without development integration openstack"
 gemfile:
 - Gemfile
 - gemfile.chef-11
-matrix:
-  exclude:
-  - rvm: 1.9.3
-    gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 3.0'
+gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '>= 12.0'
 
 group :test do

--- a/gemfile.chef-11
+++ b/gemfile.chef-11
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 3.0'
-gem 'chef',       '~> 11.16'
+gem 'berkshelf',  '~> 4.0'
+gem 'chef',       '~> 11.18'
 
 group :test do
   gem 'rake'


### PR DESCRIPTION
- upgrade to berkshelf 4
- fixes #94

Note: Berkshelf 4 dropped Ruby 1.9.3 support
 