### PR TITLE
Expose list of packages to remove as an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,16 @@ We deprecated `sysctl` version before `0.6.0`. Future versions of this cookbook 
 * `['security']['suid_sgid']['dry_run_on_unknown'] = false`
   like `remove_from_unknown` above, only that SUID/SGID bits aren't removed.
   It will still search the filesystems to look for SUID/SGID bits but it will only print them in your log. This option is only ever recommended, when you first configure `remove_from_unknown` for SUID/SGID bits, so that you can see the files that are being changed and make adjustments to your `whitelist` and `blacklist`.
-* `['security']['packages']['clean']  = true` 
-  removes packages with known issues. See section packages.
-
-## Packages
-
-We remove the following packages:
-
- * xinetd ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.1)
- * inetd ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.1)
- * tftp-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.5)
- * ypserv ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.4)
- * telnet-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.2)
- * rsh-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.3)
+* `['security']['packages']['clean'] = true` 
+  removes packages with known issues.
+* `['security']['packages']['list'] = ['xinetd','inetd','ypserv','telnet-server','rsh-server']` 
+  list of packages to remove, by default we remove the following packages:
+  * xinetd ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.1)
+  * inetd ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.1)
+  * tftp-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.5)
+  * ypserv ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.4)
+  * telnet-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.2)
+  * rsh-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.3)
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,14 @@ default['security']['init']['single']                   = false
 
 # remove packages with known issues
 default['security']['packages']['clean']               = true
+# list of packages with known issues
+default['security']['packages']['list']               = [
+  'xinetd',
+  'inetd',
+  'ypserv',
+  'telnet-server',
+  'rsh-server'
+]
 
 # SYSTEM CONFIGURATION
 # ====================

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -27,7 +27,7 @@ if node['security']['packages']['clean']
 
   # remove packages and handle virtual packages correctly.
   # this is the same package list as used for the redhat distro family
-  %w(xinetd inetd ypserv telnet-server rsh-server).each do |pkg|
+  node['security']['packages']['list'].each do |pkg|
 
     if !AptPackageExtras.virtual_package?(pkg)
       package pkg do

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -51,7 +51,7 @@ if node['security']['packages']['clean']
   end
 
   # remove packages
-  %w(xinetd inetd ypserv telnet-server rsh-server).each do |pkg|
+  node['security']['packages']['list'].each do |pkg|
     yum_package pkg do
       action :purge
     end


### PR DESCRIPTION
This follows on from my recent pull request for #90 

This exposes the list of packages to be removed by the cookbook as an attribute, with the default value of that attribute preserving the existing behaviour (i.e. creates a customisation point without a breaking change).

My primary reason for exposing this was to allow users of the cookbook to override this list should it be needed (in our specific case, we have an nagios monitoring agent that requires xinetd, which we have then taken further steps to harden) without needing to fork the cookbook.

A secondary reason is that it may make unit testing this functionality (which I am looking at for a subsequent pull request) easier.

I wasn't sure on style for README changes, so welcome any feedback.